### PR TITLE
Limit recursion and output size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,17 +9,28 @@ jobs:
       matrix:
         rust: [stable, beta, nightly]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Install Rust
       run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - run: cargo build --all
     - run: cargo test --all
 
+  fuzz_targets:
+    name: Fuzz Targets
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # Note that building with fuzzers requires nightly since it uses unstable
+    # flags to rustc.
+    - run: rustup update nightly && rustup default nightly
+    - run: cargo install cargo-fuzz --vers "^0.10"
+    - run: cargo fuzz build --dev
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup component add rustfmt
     - run: cargo fmt -- --check
@@ -28,7 +39,7 @@ jobs:
     name: Publish Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - name: Build documentation
@@ -40,4 +51,4 @@ jobs:
           git add .
           git -c user.name='ci' -c user.email='ci' commit -m init
           git push -f -q https://git:${{ secrets.github_token }}@github.com/${{ github.repository }} HEAD:gh-pages
-        if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Rust compiler symbol demangling.
 """
 
 [workspace]
-members = ["crates/capi"]
+members = ["crates/capi", "fuzz"]
 
 [dependencies]
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rustc-demangle-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+rustc-demangle = { path = '..' }
+
+[[bin]]
+name = "demangle"
+path = "fuzz_targets/demangle.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/demangle.rs
+++ b/fuzz/fuzz_targets/demangle.rs
@@ -1,0 +1,14 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use std::fmt::Write;
+
+fuzz_target!(|data: &str| {
+    let mut s = String::new();
+    let sym = rustc_demangle::demangle(data);
+    drop(write!(s, "{}", sym));
+    s.truncate(0);
+
+    if let Ok(sym) = rustc_demangle::try_demangle(data) {
+        drop(write!(s, "{}", sym));
+    }
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,4 +376,23 @@ mod tests {
             "<core::result::Result<!, E> as std::process::Termination>::report::hfc41d0da4a40b3e8"
         );
     }
+
+    #[test]
+    fn limit_recursion() {
+        use std::fmt::Write;
+        let mut s = String::new();
+        assert!(write!(s, "{}", super::demangle("_RNvB_1a")).is_err());
+    }
+
+    #[test]
+    fn limit_output() {
+        use std::fmt::Write;
+        let mut s = String::new();
+        assert!(write!(
+            s,
+            "{}",
+            super::demangle("RYFG_FGyyEvRYFF_EvRYFFEvERLB_B_B_ERLRjB_B_B_")
+        )
+        .is_err());
+    }
 }


### PR DESCRIPTION
This commit adds some rudimentary fuzzing for this crate and fixes the
fuzz bugs that it immediately encountered, namely very large recurison
and huge amounts of output. A recursion depth is added to the v0 printer
as well as a limited output printing. For now these values are not
configurable, but we could perhaps in the future add configuration if
necessary.

Closes #47