### PR TITLE
v0: don't ignore recursion limit failures from any `push_depth` calls.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,9 +418,17 @@ mod tests {
 
     #[test]
     fn limit_recursion() {
-        use std::fmt::Write;
-        let mut s = String::new();
-        assert!(write!(s, "{}", super::demangle("_RNvB_1a")).is_err());
+        // NOTE(eddyb) the `?` indicate that a parse error was encountered.
+        // FIXME(eddyb) replace `v0::Invalid` with a proper `v0::ParseError`,
+        // that could show e.g. `<recursion limit reached>` instead of `?`.
+        assert_eq!(
+            super::demangle("_RNvB_1a").to_string().replace("::a", ""),
+            "?"
+        );
+        assert_eq!(
+            super::demangle("_RMC0RB2_").to_string().replace("&", ""),
+            "<?>"
+        );
     }
 
     #[test]


### PR DESCRIPTION
#49 introduced some inconsistencies (see https://github.com/alexcrichton/rustc-demangle/pull/49#discussion_r673226227), but also left the door open for non-backref-induced stack overflows, which I'm guessing we want to avoid.

See the `recursion_limit_backref_free_bypass` test for an example of a long symbol that used to introduce a stack overflow, through sheer nested types (a long string of `R` i.e. `&` references).