### PR TITLE
Support building the C library with cargo-c

### DIFF
--- a/crates/capi/Cargo.toml
+++ b/crates/capi/Cargo.toml
@@ -14,3 +14,12 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 rustc-demangle = { version = "0.1.27", path = "../.." }
+
+[features]
+capi = []
+
+[package.metadata.capi.header]
+generation = false
+
+[package.metadata.capi.install.include]
+asset = [{ from="include/rustc_demangle.h" }]


### PR DESCRIPTION
See “If you plan to keep the bindings as a separate crate and do not need to autogenerate the headers…” in
https://github.com/lu-zero/cargo-c/tree/dd97c89dc40892b84583ed93e028124a78dc3dc3?tab=readme-ov-file#the-tldr.

Building with cargo-c is beneficial for Linux distributions in particular because it correctly handles ABI/SONAME versioning and produces pkg-config files.