### PR TITLE
Support v0 demangling of trait object types with assoc const bindings

### DIFF
--- a/src/v0.rs
+++ b/src/v0.rs
@@ -1074,7 +1074,11 @@ impl<'a, 'b, 's> Printer<'a, 'b, 's> {
             let name = parse!(self, ident);
             self.print(name)?;
             self.print(" = ")?;
-            self.print_type()?;
+            if self.eat(b'K') {
+                self.print_const(false)
+            } else {
+                self.print_type()
+            }?;
         }
 
         if open {
@@ -1348,6 +1352,11 @@ mod tests {
             "_RINbNbCskIICzLVDPPb_5alloc5alloc8box_freeDINbNiB4_5boxed5FnBoxuEp6OutputuEL_ECs1iopQbuBiw2_3std",
             "alloc::alloc::box_free::<dyn alloc::boxed::FnBox<(), Output = ()>>"
         );
+    }
+
+    #[test]
+    fn demangle_dyn_trait_assoc_const_binding() {
+        t_nohash_type!("DNtC5krate5Traitp1NKj0_EL_", "dyn krate::Trait<N = 0>");
     }
 
     #[test]


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/130300.

~~I'm blocking this until the relevant r-l/r PR is greenlit.~~

While rustc@main actually mangles assoc const bindings, it does so incorrectly since it doesn't prefix the constant with a `K` rendering the output ambiguous I'm pretty sure (prior art: const args get prefixed with `K` to distinguish them from other kinds of generic args).