### PR TITLE
`impl std::error::Error for TryDemangleError`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rustc-demangle"
 version = "0.1.27"
+edition = "2015"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustc-demangle"
 version = "0.1.27"
 edition = "2015"
+rust-version = "1.60.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/crates/capi/Cargo.toml
+++ b/crates/capi/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rustc-demangle-capi"
 version = "0.1.2"
+edition = "2015"
 authors = ["Torste Aikio <zokier@gmail.com>"]
 description = """
 C API for the `rustc-demangle` crate

--- a/crates/capi/Cargo.toml
+++ b/crates/capi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustc-demangle-capi"
 version = "0.1.2"
 edition = "2015"
+rust-version = "1.60.0"
 authors = ["Torste Aikio <zokier@gmail.com>"]
 description = """
 C API for the `rustc-demangle` crate

--- a/crates/native-c/Cargo.toml
+++ b/crates/native-c/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustc-demangle-native-c"
 edition = "2015"
 version = "0.1.0"
+rust-version = "1.60.0"
 authors = ["automatically generated"]
 description = """
 Native C version of the rustc_demangle crate

--- a/crates/native-c/Cargo.toml
+++ b/crates/native-c/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "rustc-demangle-native-c"
+edition = "2015"
 version = "0.1.0"
 authors = ["automatically generated"]
 description = """

--- a/crates/native-c/Cargo.toml
+++ b/crates/native-c/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustc-demangle-native-c"
 edition = "2015"
 version = "0.1.0"
-rust-version = "1.60.0"
+rust-version = "1.77.0"
 authors = ["automatically generated"]
 description = """
 Native C version of the rustc_demangle crate

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -46,7 +46,7 @@ pub struct Demangle<'a> {
 // Note that this demangler isn't quite as fancy as it could be. We have lots
 // of other information in our symbols like hashes, version, type information,
 // etc. Additionally, this doesn't handle glue symbols at all.
-pub fn demangle(s: &str) -> Result<(Demangle, &str), ()> {
+pub fn demangle(s: &str) -> Result<(Demangle<'_>, &str), ()> {
     // First validate the symbol. If it doesn't look like anything we're
     // expecting, we just print it literally. Note that we must handle non-Rust
     // symbols because we could have any function in the backtrace.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,15 @@ pub struct TryDemangleError {
     _priv: (),
 }
 
+impl fmt::Display for TryDemangleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TryDemangleError")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TryDemangleError {}
+
 /// The same as `demangle`, except return an `Err` if the string does not appear
 /// to be a Rust symbol, rather than "demangling" the given string as a no-op.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ enum DemangleStyle<'a> {
 /// assert_eq!(demangle("_ZN3foo3barE").to_string(), "foo::bar");
 /// assert_eq!(demangle("foo").to_string(), "foo");
 /// ```
-pub fn demangle(mut s: &str) -> Demangle {
+pub fn demangle(mut s: &str) -> Demangle<'_> {
     // During ThinLTO LLVM may import and rename internal symbols, so strip out
     // those endings first as they're one of the last manglings applied to symbol
     // names.
@@ -243,7 +243,7 @@ impl std::error::Error for TryDemangleError {}
 /// // While `demangle` will just pass the non-symbol through as a no-op.
 /// assert_eq!(rustc_demangle::demangle(not_a_rust_symbol).as_str(), not_a_rust_symbol);
 /// ```
-pub fn try_demangle(s: &str) -> Result<Demangle, TryDemangleError> {
+pub fn try_demangle(s: &str) -> Result<Demangle<'_>, TryDemangleError> {
     let sym = demangle(s);
     if sym.style.is_some() {
         Ok(sym)

--- a/src/v0.rs
+++ b/src/v0.rs
@@ -34,7 +34,7 @@ pub enum ParseError {
 /// This function will take a **mangled** symbol and return a value. When printed,
 /// the de-mangled version will be written. If the symbol does not look like
 /// a mangled symbol, the original value will be written instead.
-pub fn demangle(s: &str) -> Result<(Demangle, &str), ParseError> {
+pub fn demangle(s: &str) -> Result<(Demangle<'_>, &str), ParseError> {
     // First validate the symbol. If it doesn't look like anything we're
     // expecting, we just print it literally. Note that we must handle non-Rust
     // symbols because we could have any function in the backtrace.


### PR DESCRIPTION
Closes #61

I've also explicitly set edition in Cargo.toml manifests to 2015 to silence cargo warnings.

While we're at it, I've also run `cargo msrv` bisection and found `1.60` to be the earliest version where this still builds.
So I've set it explicitly in the manifests.

Sadly, `Error` got into `core` only in `1.81.0`, so I've used `std::error::Error` instead and gated the impl behind `feature = "std"`. Alternatively, we might consider bumping MSRV. I mean, it doesn't seem like supporting old Rust versions makes much sense for a library that parses Rust symbol mangling. Maybe it would even make sense to move this into the main monorepo? IDK.

UPD: `native-c`'s build script needs 1.77 MSRV. bumped it for the crate.

