### PR TITLE
Fix warnings about lifetimes being elided

### DIFF
--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -46,7 +46,7 @@ pub struct Demangle<'a> {
 // Note that this demangler isn't quite as fancy as it could be. We have lots
 // of other information in our symbols like hashes, version, type information,
 // etc. Additionally, this doesn't handle glue symbols at all.
-pub fn demangle(s: &str) -> Result<(Demangle, &str), ()> {
+pub fn demangle(s: &str) -> Result<(Demangle<'_>, &str), ()> {
     // First validate the symbol. If it doesn't look like anything we're
     // expecting, we just print it literally. Note that we must handle non-Rust
     // symbols because we could have any function in the backtrace.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ enum DemangleStyle<'a> {
 /// assert_eq!(demangle("_ZN3foo3barE").to_string(), "foo::bar");
 /// assert_eq!(demangle("foo").to_string(), "foo");
 /// ```
-pub fn demangle(mut s: &str) -> Demangle {
+pub fn demangle(mut s: &str) -> Demangle<'_> {
     // During ThinLTO LLVM may import and rename internal symbols, so strip out
     // those endings first as they're one of the last manglings applied to symbol
     // names.
@@ -234,7 +234,7 @@ pub struct TryDemangleError {
 /// // While `demangle` will just pass the non-symbol through as a no-op.
 /// assert_eq!(rustc_demangle::demangle(not_a_rust_symbol).as_str(), not_a_rust_symbol);
 /// ```
-pub fn try_demangle(s: &str) -> Result<Demangle, TryDemangleError> {
+pub fn try_demangle(s: &str) -> Result<Demangle<'_>, TryDemangleError> {
     let sym = demangle(s);
     if sym.style.is_some() {
         Ok(sym)

--- a/src/v0.rs
+++ b/src/v0.rs
@@ -34,7 +34,7 @@ pub enum ParseError {
 /// This function will take a **mangled** symbol and return a value. When printed,
 /// the de-mangled version will be written. If the symbol does not look like
 /// a mangled symbol, the original value will be written instead.
-pub fn demangle(s: &str) -> Result<(Demangle, &str), ParseError> {
+pub fn demangle(s: &str) -> Result<(Demangle<'_>, &str), ParseError> {
     // First validate the symbol. If it doesn't look like anything we're
     // expecting, we just print it literally. Note that we must handle non-Rust
     // symbols because we could have any function in the backtrace.


### PR DESCRIPTION
Since [Rust 1.89.0](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/), there is a new warning about such unwanted elisions, so let’s fix that with explicit elisions.