### PR TITLE
Rename splat attribute to rustc_splat

### DIFF
--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -389,4 +389,40 @@ mod tests {
             "issue_60925::foo::Foo<issue_60925::llvm::Foo>::foo"
         );
     }
+
+    #[test]
+    fn demangle_splat() {
+        // Mostly taken from rust-lang/rust/tests/ui/splat/splat-mangling.rs
+        // and rust-lang/rust/tests/ui/splat/splat-mangling-issue-158644.rs
+
+        // Single splatted argument
+        t_nohash!(
+            "_ZN14splat_mangling4main69Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u8$C$u32$RP$$RP$$GT$17hffffffffffffffffE",
+            "splat_mangling::main::Type<fn(#[rustc_splat] (u8,u32))>"
+        );
+        t_nohash!(
+            "ZN14splat_mangling4main83Type$LT$$BP$const$u20$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$RP$$GT$17hffffffffffffffffE",
+            "splat_mangling::main::Type<*const fn(#[rustc_splat] (u32,i8))>"
+        );
+        // Leading splatted argument
+        t_nohash!(
+            "_ZN14splat_mangling4main75Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hffffffffffffffffE",
+            "splat_mangling::main::Type<fn(#[rustc_splat] (u32,i8),f64)>"
+        );
+        // Trailing splatted argument
+        t_nohash!(
+            "_ZN14splat_mangling4main90Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$f64$C$$RP$$RP$$GT$17hffffffffffffffffE",
+            "splat_mangling::main::Type<*mut fn(u32,i8,#[rustc_splat] (f64,))>"
+        );
+        // Middle splatted argument
+        t_nohash!(
+            "_ZN14splat_mangling4main93Type$LT$$RF$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT$17hffffffffffffffffE",
+            "splat_mangling::main::Type<&fn(u32,#[rustc_splat] (i8,f32,usize),f64)>"
+        );
+        // Splat within splat
+        t_nohash!(
+            "_ZN14splat_mangling4main152Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hffffffffffffffffE",
+            "splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(#[rustc_splat] ()),i8),f64)>>"
+        );
+    }
 }

--- a/src/v0.rs
+++ b/src/v0.rs
@@ -904,7 +904,6 @@ impl<'a, 'b, 's> Printer<'a, 'b, 's> {
         // FIXME(splat):
         // - for efficiency we might want to use a letter that can't occur in any type, rather than
         //   taking an unused letter
-        // - splat isn't implemented for legacy mangling
         if self.eat(b'w') {
             self.print("#[rustc_splat] ")?;
         }
@@ -1376,6 +1375,10 @@ mod tests {
 
     #[test]
     fn demangle_splat() {
+        // Mostly taken from rust-lang/rust/tests/ui/splat/splat-mangling.rs
+        // and rust-lang/rust/tests/ui/splat/splat-mangling-issue-158644.rs
+
+        // Single splatted argument
         t_nohash!(
             "_RNvMNtCs5CcWRJzwAYz_4core6optionINtB2_6OptionFwTlEEuE6unwrapCsiksvdpJ6Jnj_14splat_mangling",
             "<core::option::Option<fn(#[rustc_splat] (i32,))>>::unwrap"
@@ -1392,9 +1395,25 @@ mod tests {
             "_RMs2_NvCsiksvdpJ6Jnj_14splat_mangling4mainINtB3_4TypePFwTmaEEuE",
             "<splat_mangling::main::Type<*const fn(#[rustc_splat] (u32, i8))>>"
         );
+        // Leading splatted argument
         t_nohash!(
-            "_RMs4_NvCsiksvdpJ6Jnj_14splat_mangling4mainINtB3_4TypeFwTmaEdEuE",
+            "_RMs2_NvCsiksvdpJ6Jnj_14splat_mangling4mainINtB3_4TypeFwTmaEdEuE",
             "<splat_mangling::main::Type<fn(#[rustc_splat] (u32, i8), f64)>>"
+        );
+        // Trailing splatted argument
+        t_nohash!(
+            "_RMs6_NvCsiksvdpJ6Jnj_14splat_mangling4mainINtB3_4TypeOFmawTdEEuE",
+            "<splat_mangling::main::Type<*mut fn(u32, i8, #[rustc_splat] (f64,))>>"
+        );
+        // Middle splatted argument
+        t_nohash!(
+            "_RMs8_NvCsiksvdpJ6Jnj_14splat_mangling4mainINtB3_4TypeRFmwTafjEdEuE",
+            "<splat_mangling::main::Type<&fn(u32, #[rustc_splat] (i8, f32, usize), f64)>>"
+        );
+        // Splat within splat
+        t_nohash!(
+            "_RMs2_NvCsiksvdpJ6Jnj_14splat_mangling4mainINtB3_4TypeINtNtCsiksvdpJ6Jnj_5alloc5boxed3BoxFmwTFwuEuaEdEuEE",
+            "<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[rustc_splat] (fn(#[rustc_splat] ()), i8), f64)>>>"
         );
     }
 

--- a/src/v0.rs
+++ b/src/v0.rs
@@ -906,7 +906,7 @@ impl<'a, 'b, 's> Printer<'a, 'b, 's> {
         //   taking an unused letter
         // - splat isn't implemented for legacy mangling
         if self.eat(b'w') {
-            self.print("#[splat] ")?;
+            self.print("#[rustc_splat] ")?;
         }
         let tag = parse!(self, next);
 
@@ -1378,23 +1378,23 @@ mod tests {
     fn demangle_splat() {
         t_nohash!(
             "_RNvMNtCs5CcWRJzwAYz_4core6optionINtB2_6OptionFwTlEEuE6unwrapCsiksvdpJ6Jnj_14splat_mangling",
-            "<core::option::Option<fn(#[splat] (i32,))>>::unwrap"
+            "<core::option::Option<fn(#[rustc_splat] (i32,))>>::unwrap"
         );
         t_nohash!(
             "_RMNvCsiksvdpJ6Jnj_14splat_mangling4mainINtB0_4TypeFwThmEEuE",
-            "<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>"
+            "<splat_mangling::main::Type<fn(#[rustc_splat] (u8, u32))>>"
         );
         t_nohash!(
             "_RMs0_NvCsiksvdpJ6Jnj_14splat_mangling4mainINtB3_4TypeFwTThmEEEuE",
-            "<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>"
+            "<splat_mangling::main::Type<fn(#[rustc_splat] ((u8, u32),))>>"
         );
         t_nohash!(
             "_RMs2_NvCsiksvdpJ6Jnj_14splat_mangling4mainINtB3_4TypePFwTmaEEuE",
-            "<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>"
+            "<splat_mangling::main::Type<*const fn(#[rustc_splat] (u32, i8))>>"
         );
         t_nohash!(
             "_RMs4_NvCsiksvdpJ6Jnj_14splat_mangling4mainINtB3_4TypeFwTmaEdEuE",
-            "<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>"
+            "<splat_mangling::main::Type<fn(#[rustc_splat] (u32, i8), f64)>>"
         );
     }
 


### PR DESCRIPTION
This PR:
- renames the  splat attribute to rustc_splat
- adds more tests to make sure commas are in the right place in demangling (see rust-lang/rust#160050)
- adds splat tests for legacy mangling (which always worked, without any code changes)

This is part of a fix for a name resolution clash in rustc, see rust-lang/rust#159428. The rustc fix is in rust-lang/rust#159817.

This mangling PR doesn't need to be backported, because the beta branch was before we added demangling.