### PR TITLE
Add rustfilt-like implementation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,34 @@
+//! Minimal implementation of rustc-demangle as a binary.
+//!
+//! This is not intended to be a feature-rich binary, e.g., argument parsing is unlikely to be
+//! added. However it's usable for most use cases and as of writing is ~2x faster than rustfilt.
+
+use std::io;
+use std::process::ExitCode;
+
+#[cfg(not(feature = "std"))]
+compile_error!("Currently the std feature is required for building the binary");
+
+fn main() -> ExitCode {
+    if std::env::args_os().count() > 1 {
+        eprintln!("No arguments expected. Pass input on stdin.");
+        return ExitCode::FAILURE;
+    }
+
+    let mut input = io::stdin().lock();
+    let mut output = io::stdout().lock();
+
+    let Err(e) = rustc_demangle::demangle_stream(&mut input, &mut output, false) else {
+        return ExitCode::SUCCESS;
+    };
+
+    // Don't print any extra output if we hit BrokenPipe, just exit.
+    if e.kind() == std::io::ErrorKind::BrokenPipe {
+        // FIXME: This isn't quite the same as a SIGPIPE failure, but it's probably close enough for
+        // our purposes.
+        return ExitCode::FAILURE;
+    }
+
+    eprintln!("Failed: {}", e);
+    ExitCode::FAILURE
+}


### PR DESCRIPTION
This is essentially trivial (no argument handling etc) but it would be enough for ~all of my use cases and is ~2x faster than published `rustfilt` due to the demangle_stream usage, which has landed [upstream](https://github.com/luser/rustfilt/pull/21) but hasn't been released.

@luser, would you be up for moving ownership of rustfilt on crates.io into my / T-compiler hands? I think if so, then it would make more sense to have a clean-room implementation of it (or re-license under MIT OR Apache), and then publish under that name.

If we don't hear back my suggestion is to move forward with this -- `rustfilt` has a few more features, e.g., support for file paths, `--hashes`, and demangling arguments rather than only stdin/stdout, but in my experience the implementation here is very often sufficient. This is basically zero effort to maintain, and we can (IMO) drop it if rustfilt is more actively maintained.

